### PR TITLE
Add SVG export of patterns.

### DIFF
--- a/src/style/Color.js
+++ b/src/style/Color.js
@@ -98,7 +98,7 @@ var Color = Base.extend(new function() {
 				cached = colorCache[string] = [
 					data[0] / 255,
 					data[1] / 255,
-					data[2] / 255				
+					data[2] / 255
 				];
 			}
 			components = cached.slice();
@@ -208,6 +208,16 @@ var Color = Base.extend(new function() {
 		},
 
 		'gradient-rgb': function(/* gradient */) {
+			// TODO: Implement
+			return [];
+		},
+
+		'pattern-rgb': function(/* pattern */) {
+			// TODO: Implement
+			return [];
+		},
+
+		'rgb-pattern': function(/* pattern */) {
 			// TODO: Implement
 			return [];
 		},
@@ -380,7 +390,7 @@ var Color = Base.extend(new function() {
 		 * as an alternative to providing a gradient object<br>
 		 *
 		 * @name Color#initialize
-		 * @param {Object} object an object describing the components and 
+		 * @param {Object} object an object describing the components and
 		 *        properties of the color.
 		 *
 		 * @example {@paperscript}
@@ -412,7 +422,7 @@ var Color = Base.extend(new function() {
 		 * // the path and to position the gradient color:
 		 * var topLeft = view.center - [80, 80];
 		 * var bottomRight = view.center + [80, 80];
- 		 * 
+ 		 *
 		 * var path = new Path.Rectangle({
 		 *	topLeft: topLeft,
 		 *	bottomRight: bottomRight,
@@ -1116,7 +1126,7 @@ var Color = Base.extend(new function() {
 		 *	center: view.center,
 		 *	radius: view.bounds.height * 0.4
 		 * });
-		 * 
+		 *
 		 * path.fillColor = {
 		 *	gradient: {
 		 *		stops: ['yellow', 'red', 'black'],
@@ -1125,7 +1135,7 @@ var Color = Base.extend(new function() {
 		 *	origin: path.position,
 		 *	destination: path.bounds.rightCenter
 		 * };
-		 * 
+		 *
 		 * function onMouseMove(event) {
 		 *	// Set the origin highlight of the path's gradient color
 		 *	// to the position of the mouse:


### PR DESCRIPTION
# Additions
- In `src/style/Color.js` the functions `pattern-rgb` and `rgb-pattern` are dummies required for the color code, but otherwise do nothing (as patterns are not really colors).
- In `src/svg/SVGExport.js` the pervasive `options` map can have a `pattern` key, a boolean with value `true` when the item is used in a pattern, and `undefined` or `false` otherwise.
## `exportPattern`

Uses the same general shape as the rest of the `export*` functions, i.e. look up existing patterns using `getDefinition`, and otherwise create stuff. I decided on putting patterns in the `'color'` part of the definitions simply because they are most like colors (and the rest of the pattern code is implemented like a color as well).

To create the content of the SVG pattern node I use the existing `exportSVG` function that delegates to the correct export functions for whatever elements are inside the pattern; thus, we can export both patterns created from other elements as well as from images using rasters.
### In the `attr` map

The size of the pattern is set to the bounds of the contained item to make sure that the entire pattern item is used.

The `patternUnits` is set to use a coordinate system based on the place where the pattern is inserted (I think, not quite sure I understand the specs here, but it does what I want it to do ;-) ).
# Changes
- `exportShape` function uses the `pattern` key in the `options` object.
- `exportRaster` function uses the `pattern` key in the `options` object.
- Extra spaces removed ;-)
## `exportShape`

I noticed that circle shapes exported as part of patterns would be shifted towards the top left corner. To show the entire shape in the pattern I am adding the radius of the circle to both the `x` and `y` axis, as that will shift the circle to the center of the generated SVG circle. This is why the `pattern` option is necessary for `exportShape`.
## `exportRaster`

For rasters I experienced the same as for shapes, i.e. the generated objects would be shifted away from the center. To fix this I conditionally remove the "take into account that rasters are centered" part of the code if the `options` object contains `pattern: true`.
