### PR TITLE
Empty arrays yield invalid SVGs

### DIFF
--- a/src/svg/SVGExport.js
+++ b/src/svg/SVGExport.js
@@ -338,7 +338,9 @@ new function() {
 									? exportPattern(value, item)
 									: value.toCSS(true)
 							: type === 'array'
-								? value.join(',')
+								? value[0]
+									? value.join(',')
+									: 'none'
 								: type === 'lookup'
 									? entry.toSVG[value]
 									: value;


### PR DESCRIPTION
A problem with the existing paper.js code would result in empty arrays yielding invalid attribute values, e.g. `stroke-dash-array=""`. This fixes that such that empty arrays yield e.g. `stroke-dash-array="none"` instead, which is valid SVG.
