### PR TITLE
Make lookup types 'inherit' instead of 'none'.

### DIFF
--- a/src/svg/SVGExport.js
+++ b/src/svg/SVGExport.js
@@ -327,7 +327,7 @@ new function() {
 						attrs[entry.attribute + '-opacity'] = alpha;
 				}
 				attrs[entry.attribute] = value == null
-					? type === 'number'
+					? ((type === 'number') || (type === 'lookup'))
 						? 'inherit'
 						: 'none'
 					: type === 'number'


### PR DESCRIPTION
Sorry for spamming PRs, but I noticed a flaw in the PR from yesterday: lookup types, e.g. `text-anchor`, cannot have value 'none', so it needs to have 'inherit' like numbers.
