### PR TITLE
Comment out closed path handling in PathFitter.

### DIFF
--- a/dist/paper-core.js
+++ b/dist/paper-core.js
@@ -9,7 +9,7 @@
  *
  * All rights reserved.
  *
- * Date: Wed Jan 21 11:20:43 2015 +0100
+ * Date: Wed Jan 21 14:59:21 2015 +0100
  *
  ***
  *
@@ -9053,12 +9053,6 @@ var PathFitter = Base.extend({
 				points.push(point);
 				prev = point;
 			}
-		}
-
-		if (path._closed) {
-			this.closed = true;
-			points.unshift(points[points.length - 1]);
-			points.push(points[1]);
 		}
 
 		this.error = error;

--- a/dist/paper-full.js
+++ b/dist/paper-full.js
@@ -9,7 +9,7 @@
  *
  * All rights reserved.
  *
- * Date: Wed Jan 21 11:20:43 2015 +0100
+ * Date: Wed Jan 21 14:59:21 2015 +0100
  *
  ***
  *
@@ -9053,12 +9053,6 @@ var PathFitter = Base.extend({
 				points.push(point);
 				prev = point;
 			}
-		}
-
-		if (path._closed) {
-			this.closed = true;
-			points.unshift(points[points.length - 1]);
-			points.push(points[1]);
 		}
 
 		this.error = error;

--- a/dist/paper-node.js
+++ b/dist/paper-node.js
@@ -9,7 +9,7 @@
  *
  * All rights reserved.
  *
- * Date: Wed Jan 21 11:20:43 2015 +0100
+ * Date: Wed Jan 21 14:59:21 2015 +0100
  *
  ***
  *
@@ -9047,12 +9047,6 @@ var PathFitter = Base.extend({
 				points.push(point);
 				prev = point;
 			}
-		}
-
-		if (path._closed) {
-			this.closed = true;
-			points.unshift(points[points.length - 1]);
-			points.push(points[1]);
 		}
 
 		this.error = error;

--- a/src/path/PathFitter.js
+++ b/src/path/PathFitter.js
@@ -34,13 +34,18 @@ var PathFitter = Base.extend({
             }
         }
 
+        // ~~INGO COMMENT~~
+        // ~~~~~~~~~~~~~~~~
+        // Commented out because it cuts too many corners, making simplified and not simplified
+        // versions to be noticeably different
+
         // We need to duplicate the first and last segment when simplifying a
         // closed path.
-        if (path._closed) {
-            this.closed = true;
-            points.unshift(points[points.length - 1]);
-            points.push(points[1]); // The point previously at index 0 is now 1.
-        }
+        // if (path._closed) {
+        //     this.closed = true;
+        //     points.unshift(points[points.length - 1]);
+        //     points.push(points[1]); // The point previously at index 0 is now 1.
+        // }
 
         this.error = error;
     },


### PR DESCRIPTION
It cuts too many corners, making simplified and original path to
noticeably differ

With:
![screen shot 2015-01-28 at 15 37 19](https://cloud.githubusercontent.com/assets/2392131/5939409/beb3b8e4-a703-11e4-9ca5-513c10168cc5.png)
![screen shot 2015-01-28 at 15 37 34](https://cloud.githubusercontent.com/assets/2392131/5939410/bec7710e-a703-11e4-8422-2327cb843ccf.png)

Without:
![screen shot 2015-01-28 at 15 39 31](https://cloud.githubusercontent.com/assets/2392131/5939430/eaacd6e2-a703-11e4-8a25-e4a01e56afc4.png)
![screen shot 2015-01-28 at 15 39 38](https://cloud.githubusercontent.com/assets/2392131/5939431/eaad313c-a703-11e4-8a3d-18e80ff83853.png)
